### PR TITLE
1bpp image problems

### DIFF
--- a/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/Glasses.java
+++ b/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/Glasses.java
@@ -346,7 +346,7 @@ public interface Glasses extends Parcelable {
      *
      * @param data 1bpp Image data configuration object.
      */
-    void imgSave1bpp(Image1bppData data);
+    void imgSave1bpp(byte id, Image1bppData data);
     /**
      * Give the list of font saved into the device with their size.
      *

--- a/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/core/AbstractGlasses.java
+++ b/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/core/AbstractGlasses.java
@@ -423,8 +423,9 @@ public abstract class AbstractGlasses implements Glasses {
     }
 
     // TODO @Override
-    public void imgSave1bpp(final int width, final byte[] bytes) {
+    public void imgSave1bpp(final byte id, final int width, final byte[] bytes) {
         final CommandData data = new CommandData()
+                .addUInt8(id)
                 .addUInt32(bytes.length)
                 .addUInt16(width);
         this.writeCommand(new Command(ID_imgSave1bpp, data));
@@ -434,8 +435,8 @@ public abstract class AbstractGlasses implements Glasses {
     }
 
     @Override
-    public void imgSave1bpp(final Image1bppData imgData) {
-        this.imgSave1bpp(imgData.getWidth(), imgData.getBytes());
+    public void imgSave1bpp(final byte id, final Image1bppData imgData) {
+        this.imgSave1bpp(id, imgData.getWidth(), imgData.getBytes());
     }
 
     @Override

--- a/debugapp/src/main/java/com/activelook/debugapp/DebugActivity.java
+++ b/debugapp/src/main/java/com/activelook/debugapp/DebugActivity.java
@@ -325,7 +325,7 @@ public class DebugActivity extends AppCompatActivity {
         g.cfgWrite("DebugApp", 1, 42);
 
         g.imgSave((byte) 0x01, img1);
-        g.imgSave1bpp(img2);
+        g.imgSave1bpp((byte) 0x02, img2);
         g.imgStream(img2, (short) 20, (short) 30);
 
         g.imgList(l -> {

--- a/demoapp/src/main/java/com/activelook/demo/BitmapsCommands.java
+++ b/demoapp/src/main/java/com/activelook/demo/BitmapsCommands.java
@@ -189,7 +189,7 @@ public class BitmapsCommands extends MainActivity2 {
                 }),
                 item("imgSave1bpp", glasses -> {
                     glasses.cfgWrite("DemoApp", 1, 42);
-                    glasses.imgSave1bpp(img2);
+                    glasses.imgSave1bpp((byte) 0x03, img2);
                 }),
                 item("imgDisplay", glasses -> {
                     glasses.clear();


### PR DESCRIPTION
The 1bpp image save was missing an `id` parameter.
The chunking should be set per-line of the image, not fixed to 240 bytes.