### PR TITLE
Direct connect to a device

### DIFF
--- a/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/Sdk.java
+++ b/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/Sdk.java
@@ -56,4 +56,17 @@ public interface Sdk {
      */
     boolean isScanning();
 
+    /**
+     * Connect to glasses given an address and call callback on success.
+     *
+     * @param onConnected      Callback to call on success
+     * @param onConnectionFail Callback to call on failure
+     * @param onDisconnected   Callback to set for disconnected events.
+     */
+    void connect(
+            String address,
+            Consumer<Glasses> onConnected,
+            Consumer<String> onConnectionFail,
+            Consumer<Glasses> onDisconnected
+    );
 }

--- a/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/Sdk.java
+++ b/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/Sdk.java
@@ -69,4 +69,13 @@ public interface Sdk {
             Consumer<String> onConnectionFail,
             Consumer<Glasses> onDisconnected
     );
+
+    /**
+     * Close the connection to the glasses. This is supposed to be called to cancel
+     * connection that has not connected yet and thus the glasses object is not
+     * available.
+     *
+     * @param address Address of the glasses being connected
+     */
+    void stopConnect(String address);
 }

--- a/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/core/ble/SdkImpl.java
+++ b/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/core/ble/SdkImpl.java
@@ -84,6 +84,14 @@ class SdkImpl implements Sdk {
         registerConnectedGlasses(new GlassesImpl(address, onConnected, onConnectionFail, onDisconnected));
     }
 
+    @Override
+    public void stopConnect(String address) {
+        GlassesImpl gls = connectedGlasses.get(address);
+        if (gls != null) {
+            gls.disconnect();
+        }
+    }
+
     void registerConnectedGlasses(GlassesImpl bleGlasses) {
         this.connectedGlasses.put(bleGlasses.getAddress(), bleGlasses);
     }

--- a/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/core/ble/SdkImpl.java
+++ b/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/core/ble/SdkImpl.java
@@ -24,6 +24,7 @@ import android.widget.Toast;
 import androidx.core.util.Consumer;
 
 import com.activelook.activelooksdk.DiscoveredGlasses;
+import com.activelook.activelooksdk.Glasses;
 import com.activelook.activelooksdk.Sdk;
 import com.activelook.activelooksdk.exceptions.UnsupportedBleException;
 
@@ -33,7 +34,7 @@ class SdkImpl implements Sdk {
 
     private final Context context;
     private final BluetoothManager manager;
-    private final BluetoothAdapter adapter;
+    final BluetoothAdapter adapter;
     private final BluetoothLeScanner scanner;
     private final HashMap<String, GlassesImpl> connectedGlasses = new HashMap<>();
     private ScanCallback scanCallback;
@@ -71,6 +72,16 @@ class SdkImpl implements Sdk {
     @Override
     public boolean isScanning() {
         return this.scanCallback != null;
+    }
+
+    @Override
+    public void connect(
+            String address,
+            Consumer<Glasses> onConnected,
+            Consumer<String> onConnectionFail,
+            Consumer<Glasses> onDisconnected
+    ) {
+        registerConnectedGlasses(new GlassesImpl(address, onConnected, onConnectionFail, onDisconnected));
     }
 
     void registerConnectedGlasses(GlassesImpl bleGlasses) {

--- a/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/core/debug/GlassesImpl.java
+++ b/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/core/debug/GlassesImpl.java
@@ -37,31 +37,46 @@ class GlassesImpl extends AbstractGlasses implements Glasses {
             return new GlassesImpl[size];
         }
     };
-    private DiscoveredGlassesImpl connectedFrom;
+
+    private String name;
+    private String address;
+    private String manufacturer;
 
     GlassesImpl(DiscoveredGlassesImpl discoveredGlasses, Consumer<Glasses> onConnected) {
         super();
-        this.connectedFrom = discoveredGlasses;
+        name = discoveredGlasses.getName();
+        address = discoveredGlasses.getAddress();
+        this.manufacturer = discoveredGlasses.getManufacturer();
+        onConnected.accept(this);
+    }
+    GlassesImpl(String address, Consumer<Glasses> onConnected) {
+        super();
+        name = "";
+        address = address;
+        manufacturer = "";
         onConnected.accept(this);
     }
 
+
     protected GlassesImpl(Parcel in) {
-        this.connectedFrom = in.readParcelable(DiscoveredGlassesImpl.class.getClassLoader());
+        name = in.readString();
+        address = in.readString();
+        manufacturer = in.readString();
     }
 
     @Override
     public String getManufacturer() {
-        return this.connectedFrom.getManufacturer();
+        return this.manufacturer;
     }
 
     @Override
     public String getName() {
-        return this.connectedFrom.getName();
+        return this.name;
     }
 
     @Override
     public String getAddress() {
-        return this.connectedFrom.getAddress();
+        return this.address;
     }
 
     @Override
@@ -117,11 +132,15 @@ class GlassesImpl extends AbstractGlasses implements Glasses {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        dest.writeParcelable(this.connectedFrom, flags);
+        dest.writeString(name);
+        dest.writeString(address);
+        dest.writeString(manufacturer);
     }
 
     public void readFromParcel(Parcel source) {
-        this.connectedFrom = source.readParcelable(DiscoveredGlassesImpl.class.getClassLoader());
+        name = source.readString();
+        address = source.readString();
+        manufacturer = source.readString();
     }
 
 }

--- a/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/core/debug/SdkImpl.java
+++ b/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/core/debug/SdkImpl.java
@@ -20,6 +20,7 @@ import android.util.Log;
 import androidx.core.util.Consumer;
 
 import com.activelook.activelooksdk.DiscoveredGlasses;
+import com.activelook.activelooksdk.Glasses;
 import com.activelook.activelooksdk.Sdk;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -57,6 +58,15 @@ class SdkImpl implements Sdk {
     @Override
     public boolean isScanning() {
         return this.isScanning.get();
+    }
+
+    @Override
+    public void connect(
+            String address, Consumer<Glasses> onConnected,
+            Consumer<String> onConnectionFail,
+            Consumer<Glasses> onDisconnected
+    ) {
+        new GlassesImpl(address, onConnected);
     }
 
 }

--- a/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/core/debug/SdkImpl.java
+++ b/ActiveLookSDK/src/main/java/com/activelook/activelooksdk/core/debug/SdkImpl.java
@@ -69,4 +69,7 @@ class SdkImpl implements Sdk {
         new GlassesImpl(address, onConnected);
     }
 
+    @Override
+    public void stopConnect(String address) {
+    }
 }


### PR DESCRIPTION
This patch adds the ability to directly connect to the glasses given the address. However, I'm not 100% sure if this is completely correct way to approach it, so I'm open to do additional changes:

- it doesn't require `scan`; that means that it is possible to connect to the glasses even when positioning services (GPS - in the system preferences) are disabled 
- I'm not sure how would it work on older android devices; the texts on the internet seems to indicate that scanning is needed. On my Android 11 it seems to work, I'll try it on Android 9 soon
- I'm not using the parcelable interface, so I'm really not sure if I did the correct thing here
- I'm not sure how to get to the manufacturer id without a scan, so this is probably not quite corect (btw - is there a list of the manufacturer ids?)